### PR TITLE
Fix "-Wwrite-strings" warnings by adding some "const"s.

### DIFF
--- a/code/DrumVarView.cpp
+++ b/code/DrumVarView.cpp
@@ -477,8 +477,8 @@ void DrumVarView::MessageReceived(BMessage *message)
 	}
 }
 
-void DrumVarView::Openslider(BPoint here, char * winname, uint32 msg_val, 
-		uint drum, uint val, uint low, uint high, char * lowlabel, char * highlabel)
+void DrumVarView::Openslider(BPoint here, const char * winname, uint32 msg_val,
+		uint drum, uint val, uint low, uint high, const char * lowlabel, const char * highlabel)
 {
 	BRect		frame;
 	BSlider		*slider;
@@ -523,7 +523,7 @@ const char * DrumVarView::Instname(uint drum)
 
 /* loop through the window list of the application, looking for
    a window with a specified name. */
-BWindow	*DrumVarView::GetAppWindow(char *name)
+BWindow	*DrumVarView::GetAppWindow(const char *name)
 {
 	int32		index;
 	BWindow		*window;

--- a/code/DrumVarView.h
+++ b/code/DrumVarView.h
@@ -32,11 +32,11 @@ public:
  	virtual void 	Pulse(void);
  	virtual void 	MouseDown(BPoint point);
 	void			MessageReceived(BMessage *);	
-	void			Openslider(BPoint here, char * winname, uint32 msg_val, 
-		uint drum, uint val, uint low, uint high, char * lowlabel, 
-		char * highlabel);
+	void			Openslider(BPoint here, const char * winname, uint32 msg_val,
+		uint drum, uint val, uint low, uint high, const char * lowlabel,
+		const char * highlabel);
 	const char *	Instname(uint drum);
-	BWindow *		GetAppWindow(char *name);
+	BWindow *		GetAppWindow(const char *name);
 			
 
 	//----------------------------------------------------------------


### PR DESCRIPTION
The one on winname/GetAppWindow() was not strictly necessary, but... doesn't hurts :-)

Properly fixing the remaining warnings is beyond my limited skills, sadly.

Edit: warnings were present only when building with newer GCC.